### PR TITLE
Add Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: perl6
+
+perl6:
+    - latest
+
+install:
+    - rakudobrew build-panda
+    - panda installdeps .


### PR DESCRIPTION
Assuming #2 gets merged (or a variant thereof), then this patch should get Travis builds running and passing.